### PR TITLE
Change module path from `mholt/caddy-ratelimit` to `popcorn/caddy-ratelimit`.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Build
       run: |
-        xcaddy build master --output ${{ runner.temp }}/${{ matrix.name }} --with github.com/mholt/caddy-ratelimit=./
+        xcaddy build master --output ${{ runner.temp }}/${{ matrix.name }} --with github.com/popcorn/caddy-ratelimit=./
         # smoking test
         echo ''
         echo '########'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This module implements both internal and distributed HTTP rate limiting. Request
 To build Caddy with this module, use [xcaddy](https://github.com/caddyserver/xcaddy):
 
 ```bash
-$ xcaddy build --with github.com/mholt/caddy-ratelimit
+$ xcaddy build --with github.com/popcorn/caddy-ratelimit
 ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mholt/caddy-ratelimit
+module github.com/popcorn/caddy-ratelimit
 
 go 1.21.0
 


### PR DESCRIPTION
# Why?

xcaddy build fails otherwise.